### PR TITLE
fix: process metrics in 429 errors, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, you should export the following environment variables to access Azure mana
 ```sh
 docker run --rm -it -p 8080:8080 \
     -e AZURE_CLIENT_ID -e AZURE_TENANT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID \
-    palmerabollo/azure-throttling-exporter:0.2.2
+    palmerabollo/azure-throttling-exporter:0.2.3
 ```
 
 Open [localhost:8080](http://localhost:8080) to get the exposed metrics:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.baikalplatform</groupId>
     <artifactId>azure-throttling-exporter</artifactId>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
When Azure returns a HTTP 429 status code (too many requests), update the prometheus gauge, too.